### PR TITLE
Added gLike as child of musNote

### DIFF
--- a/tei_rilm.xsd
+++ b/tei_rilm.xsd
@@ -8334,6 +8334,7 @@ Sample values include: 1] glued; 2] pinned; 3] sewn</xs:documentation>
       <xs:documentation>Contains the name of a musical note without reference to a particular octave or pitch.</xs:documentation>
     </xs:annotation>
     <xs:complexType mixed="true">
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:rilmteimodel.gLike"/>
       <xs:attributeGroup ref="tei:rilmteiatt.global.attributes"/>
       <xs:attributeGroup ref="tei:rilmteiatt.typed.attributes"/>
     </xs:complexType>


### PR DESCRIPTION
@kyarmey - okay with this? If so, can merge.

Use case was a `<musNote>f<g type="smufl" ref="accidentalSori"></g></musNote>` pointing to https://www.smufl.org/version/latest/glyph/accidentalSori/ in the MGG Iran article. I've made the change in the Fonto copy of the schema to get it up and running, and realized that wasn't actually linked to this repo. Will set that up as soon as this is merged.